### PR TITLE
event loop must be started before window show for linux

### DIFF
--- a/docs/window.md
+++ b/docs/window.md
@@ -13,9 +13,8 @@ win.onClosing(function () {
 	libui.stopLoop();
 });
 
-win.show();
-
 libui.startLoop();
+win.show();
 ```
 
 The UiWindow class is responsible to show and manage native windows.


### PR DESCRIPTION
I was working through the examples and I noticed that nothing worked on linux unless I switched the order of the `show()` call and the `startLoop()` call. This switches the order in the window example file.

edit: for clarification, without this change, the window will never open on linux (at least on the two Ubuntu 16.04 and 17.10 systems I've tried).