### PR TITLE
Change rpath to ORIGIN

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -68,7 +68,7 @@
 			            }
 			          },
 					'ldflags': [
-						"-Wl,-rpath,'$$ORIGIN'",
+						"-Wl,-rpath,'$$ORIGIN',-rpath,<(module_root_dir)",
 					],"cflags": [
 						"-std=c++11",
 					 	"-stdlib=libc++"
@@ -80,7 +80,7 @@
 						"src/arch/unix/uiConnectionNumber.cc"
 					],
 					'ldflags': [
-						"-Wl,-rpath,'$$ORIGIN'",
+						"-Wl,-rpath,'$$ORIGIN',-rpath,<(module_root_dir)",
 					],
 					"libraries": [
 						"<(module_root_dir)/libui.so"
@@ -98,7 +98,9 @@
 							"-L<(module_root_dir)",
 							"-lui",
 							"-rpath",
-							"'$$ORIGIN'"
+							"'$$ORIGIN'",
+							"-rpath",
+							"<(module_root_dir)"
 						]
 					}
 				}],

--- a/binding.gyp
+++ b/binding.gyp
@@ -97,7 +97,8 @@
 						"OTHER_LDFLAGS": [
 							"-L<(module_root_dir)",
 							"-lui",
-							"-rpath,'$$ORIGIN'"
+							"-rpath",
+							"'$$ORIGIN'"
 						]
 					}
 				}],

--- a/binding.gyp
+++ b/binding.gyp
@@ -68,7 +68,7 @@
 			            }
 			          },
 					'ldflags': [
-						'-Wl,-rpath,<(module_root_dir)',
+						"-Wl,-rpath,'$$ORIGIN'",
 					],"cflags": [
 						"-std=c++11",
 					 	"-stdlib=libc++"
@@ -80,7 +80,7 @@
 						"src/arch/unix/uiConnectionNumber.cc"
 					],
 					'ldflags': [
-						'-Wl,-rpath,<(module_root_dir)',
+						"-Wl,-rpath,'$$ORIGIN'",
 					],
 					"libraries": [
 						"<(module_root_dir)/libui.so"
@@ -97,8 +97,7 @@
 						"OTHER_LDFLAGS": [
 							"-L<(module_root_dir)",
 							"-lui",
-							"-rpath",
-							"<(module_root_dir)"
+							"-rpath,'$$ORIGIN'"
 						]
 					}
 				}],


### PR DESCRIPTION
This lets libui-node work with packaging system like pkg and nexe. The rpath used to be an absolute path, meaning that it could not be moved. This should fix that. I'm not 100% certain if this works on Windows since I currently don't have a Windows box to test on.

~~Edit: Seems like I tested it wrong. I'll see if I can figure out a solution that works with both systems.~~
All compiles work now!