### PR TITLE
Fix rpath for macOS

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -98,7 +98,7 @@
 							"-L<(module_root_dir)",
 							"-lui",
 							"-rpath",
-							"'$$ORIGIN'",
+							"'@loader_path'",
 							"-rpath",
 							"<(module_root_dir)"
 						]


### PR DESCRIPTION
#58
Now `libui.A.dylib` can also be in same directory as `nbind.node`.

Should be changed in the `0_1_0` branch as well.