### PR TITLE
Copy nbind.node into root and cleanup win target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,7 @@ _libui
 *.h
 
 *.dylib
+nbind.node
+*.dll
+*.exp
+*.lib

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,6 +1,7 @@
 {
 	"targets": [
 		{
+			"target_name": "nbind",
 			"includes": [
 				"auto.gypi"
 			],
@@ -60,19 +61,13 @@
 						"<(module_root_dir)/libui.lib"
 					],
 					'msvs_settings': {
-			            'VCCLCompilerTool': {
-			              'AdditionalOptions': [
-			                '/MD',
-			                '/LD'
-			              ]
-			            }
-			          },
-					'ldflags': [
-						"-Wl,-rpath,'$$ORIGIN',-rpath,<(module_root_dir)",
-					],"cflags": [
-						"-std=c++11",
-					 	"-stdlib=libc++"
-					]
+						'VCCLCompilerTool': {
+							'AdditionalOptions': [
+								'/MD',
+								'/LD'
+							]
+						}
+					},
 				}],
 				["OS=='linux'", {
 					"sources": [
@@ -105,7 +100,18 @@
 					}
 				}],
 			]
-		}
+		},
+		{
+			"target_name": "copy_binary",
+			"type":"none",
+			"dependencies": [ "nbind" ],
+			"copies": [
+				{
+					'destination': '<(module_root_dir)',
+					'files': ['<(module_root_dir)/build/Release/nbind.node']
+				}
+			]
+	   }
 	],
 	"includes": [
 		"auto-top.gypi"


### PR DESCRIPTION
nbind.node get's copied to the root directory after building.
(https://github.com/parro-it/libui-node/pull/58#issuecomment-372144662)

The compiler flags for windows weren't used and wouldn't work anyway (rpath doesn't exist on windows and there is no C++11 flag).