### PR TITLE
Fix examples and docs regarding Ui.init

### DIFF
--- a/docs/area.md
+++ b/docs/area.md
@@ -10,7 +10,7 @@ UiArea provide a canvas you can draw on. It also receives keyboard and mouse eve
 var libui = require('libui');
 var colorDodgerBlue = 0x1E90FF;
 var uiDrawFillModeWinding = 0;
-libui.Ui.init();
+
 var win = new libui.UiWindow('UiEntry example', 640, 480, true);
 
 var handler = {

--- a/docs/button.md
+++ b/docs/button.md
@@ -6,10 +6,8 @@
 ![UiButton example](media/UiButton.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiButton example', 640, 480, true);
 
 var widget = new libui.UiButton();

--- a/docs/checkbox.md
+++ b/docs/checkbox.md
@@ -6,10 +6,8 @@
 ![UiCheckbox example](media/UiCheckbox.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiCheckbox example', 640, 480, true);
 
 var widget = new libui.UiCheckbox();

--- a/docs/colorbutton.md
+++ b/docs/colorbutton.md
@@ -6,10 +6,8 @@
 ![UiColorButton example](media/UiColorButton.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiColorButton example', 640, 480, true);
 
 var widget = new libui.UiColorButton();

--- a/docs/combobox.md
+++ b/docs/combobox.md
@@ -6,10 +6,8 @@
 ![UiCombobox example](media/UiCombobox.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiCombobox example', 640, 480, true);
 
 var widget = new libui.UiCombobox();

--- a/docs/datepicker.md
+++ b/docs/datepicker.md
@@ -6,10 +6,8 @@
 ![UiDatePicker example](media/UiDatePicker.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiDatePicker example', 640, 480, true);
 
 var widget = new libui.UiDatePicker();

--- a/docs/datetimepicker.md
+++ b/docs/datetimepicker.md
@@ -6,10 +6,8 @@
 ![UiDateTimePicker example](media/UiDateTimePicker.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiDateTimePicker example', 640, 480, true);
 
 var widget = new libui.UiDateTimePicker();

--- a/docs/editablecombobox.md
+++ b/docs/editablecombobox.md
@@ -6,10 +6,8 @@
 ![UiEditableCombobox example](media/UiEditableCombobox.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiEditableCombobox example', 640, 480, true);
 
 var widget = new libui.UiEditableCombobox();

--- a/docs/entry.md
+++ b/docs/entry.md
@@ -6,10 +6,8 @@
 ![UiEntry example](media/UiEntry.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiEntry example', 640, 480, true);
 
 var widget = new libui.UiEntry();

--- a/docs/form.md
+++ b/docs/form.md
@@ -6,10 +6,8 @@
 ![UiForm example](media/UiForm.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiForm example', 640, 480, true);
 
 var widget = new libui.UiForm();

--- a/docs/grid.md
+++ b/docs/grid.md
@@ -6,10 +6,8 @@
 ![UiGrid example](media/UiGrid.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiGrid example', 640, 480, true);
 
 var widget = new libui.UiGrid();

--- a/docs/group.md
+++ b/docs/group.md
@@ -6,10 +6,8 @@
 ![UiGroup example](media/UiGroup.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiGroup example', 640, 480, true);
 
 var widget = new libui.UiGroup();

--- a/docs/horizontalbox.md
+++ b/docs/horizontalbox.md
@@ -6,10 +6,8 @@
 ![UiHorizontalBox example](media/UiHorizontalBox.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiHorizontalBox example', 640, 480, true);
 
 var widget = new libui.UiHorizontalBox();

--- a/docs/horizontalseparator.md
+++ b/docs/horizontalseparator.md
@@ -6,10 +6,8 @@
 ![UiHorizontalSeparator example](media/UiHorizontalSeparator.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiHorizontalSeparator example', 640, 480, true);
 
 var widget = new libui.UiHorizontalSeparator();

--- a/docs/initialization.md
+++ b/docs/initialization.md
@@ -1,23 +1,8 @@
-# Libui-node initialization
-
-`libui-node` must be initialized to be able to create any GUI control.
-This can be done by calling the `init` method:
-
-```js
-var libui = require('libui');
-
-libui.Ui.init();
-```
-
-After initialization, you can freely create windows or control objects.
-
-
 # Event loop
 
 `libui-node` has an event loop independent  of the Node.js one that take care of processing GUI events. It process events one tick at a time, so it can run seamlessy with Node.js loop.
 
 Each bit of GUI event loop is executed by a call to `libui.Ui.mainStep` method. This method could be used directly by your code, or you can leverage the `startLoop` event that continuosly schedules calls to `mainStep` using Node.js `setImmediate` function.
-
 
 
 ## Start the event loop
@@ -26,6 +11,8 @@ To start the event loop, you simply call the `startLoop` method. The function re
 
 
 ```js
+var libui = require('libui');
+
 libui.startLoop(function () {
 	console.log('event loop terminated.');
 });
@@ -54,8 +41,6 @@ To stop the loop and allow `main` method to return, you have to call `libui.Ui.q
 
 ```js
 var libui = require('libui');
-
-libui.Ui.init();
 
 var window = libui.UiWindow(title, width, height, hasMenubar);
 

--- a/docs/label.md
+++ b/docs/label.md
@@ -6,10 +6,8 @@
 ![UiLabel example](media/UiLabel.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiLabel example', 640, 480, true);
 
 var widget = new libui.UiLabel();

--- a/docs/multilineentry.md
+++ b/docs/multilineentry.md
@@ -6,10 +6,8 @@
 ![UiMultilineEntry example](media/UiMultilineEntry.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiMultilineEntry example', 640, 480, true);
 
 var widget = new libui.UiMultilineEntry();

--- a/docs/passwordentry.md
+++ b/docs/passwordentry.md
@@ -6,10 +6,8 @@
 
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiPasswordEntry example', 640, 480, true);
 
 var widget = new libui.UiPasswordEntry();

--- a/docs/progressbar.md
+++ b/docs/progressbar.md
@@ -6,10 +6,8 @@
 ![UiProgressBar example](media/UiProgressBar.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiProgressBar example', 640, 480, true);
 
 var widget = new libui.UiProgressBar();

--- a/docs/radiobuttons.md
+++ b/docs/radiobuttons.md
@@ -6,10 +6,8 @@
 ![UiRadioButtons example](media/UiRadioButtons.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiRadioButtons example', 640, 480, true);
 
 var widget = new libui.UiRadioButtons();

--- a/docs/searchentry.md
+++ b/docs/searchentry.md
@@ -6,10 +6,8 @@
 
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiSearchEntry example', 640, 480, true);
 
 var widget = new libui.UiSearchEntry();

--- a/docs/slider.md
+++ b/docs/slider.md
@@ -6,10 +6,8 @@
 ![UiSlider example](media/UiSlider.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiSlider example', 640, 480, true);
 
 var widget = new libui.UiSlider();

--- a/docs/spinbox.md
+++ b/docs/spinbox.md
@@ -6,10 +6,8 @@
 ![UiSpinbox example](media/UiSpinbox.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiSpinbox example', 640, 480, true);
 
 var widget = new libui.UiSpinbox();

--- a/docs/tab.md
+++ b/docs/tab.md
@@ -6,10 +6,8 @@
 ![UiTab example](media/UiTab.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiTab example', 640, 480, true);
 
 var widget = new libui.UiTab();

--- a/docs/timepicker.md
+++ b/docs/timepicker.md
@@ -6,10 +6,8 @@
 ![UiTimePicker example](media/UiTimePicker.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiTimePicker example', 640, 480, true);
 
 var widget = new libui.UiTimePicker();

--- a/docs/verticalbox.md
+++ b/docs/verticalbox.md
@@ -6,10 +6,8 @@
 ![UiVerticalBox example](media/UiVerticalBox.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiVerticalBox example', 640, 480, true);
 
 var widget = new libui.UiVerticalBox();

--- a/docs/verticalseparator.md
+++ b/docs/verticalseparator.md
@@ -6,10 +6,8 @@
 ![UiVerticalSeparator example](media/UiVerticalSeparator.png)
 
 ```js
-
 var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiVerticalSeparator example', 640, 480, true);
 
 var widget = new libui.UiVerticalSeparator();

--- a/docs/window.md
+++ b/docs/window.md
@@ -5,8 +5,6 @@
 ```js
 var libui = require('libui');
 
-libui.Ui.init();
-
 var win = new libui.UiWindow("Example window", 640, 480, true);
 
 win.onClosing(function () {

--- a/examples/check-memory.js
+++ b/examples/check-memory.js
@@ -2,8 +2,6 @@ var humanize = require('humanize');
 var procStats = require('proc-stats');
 var libui = require('../index.js');
 
-libui.Ui.init();
-
 function openBigWindow() {
 	var win = new libui.UiWindow('Forms window', 80, 60, false);
 	win.margined = 1;

--- a/examples/control-gallery.js
+++ b/examples/control-gallery.js
@@ -164,7 +164,7 @@ menu([
 			},
 			{
 				label: "Disabled Item",
-				click: () => {}
+				disabled: true
 			},
 			{
 				role: "preferences"

--- a/examples/docs.js
+++ b/examples/docs.js
@@ -28,10 +28,8 @@ function writeFile(name, description, ...contents) {
 	const image = existsSync(imagePath) ? `![${name} example](media/${name}.png)` : '';
 	readme += `
 * [${name}](${filename}) - ${description}`;
-	const code = `
-var libui = require('libui');
+	const code = `var libui = require('libui');
 
-libui.Ui.init();
 var win = new libui.UiWindow('${name} example', 640, 480, true);
 
 var widget = new libui.${name}();
@@ -529,7 +527,6 @@ writeFile('UiGroup', 'A container for a single widget that provide a caption and
 /*
 var libui = require('../index.js');
 
-libui.Ui.init();
 
 var win = new libui.UiWindow("Example window", 640, 480, true);
 win.borderless = true;

--- a/examples/forms.js
+++ b/examples/forms.js
@@ -1,6 +1,5 @@
 var libui = require('../index.js');
 
-libui.Ui.init();
 var win = new libui.UiWindow('Forms window', 800, 600, false);
 win.margined = 1;
 win.onClosing(function () {

--- a/examples/grid.js
+++ b/examples/grid.js
@@ -1,6 +1,5 @@
 var libui = require('../index.js');
 
-libui.Ui.init();
 var win = new libui.UiWindow('Forms window', 800, 600, false);
 win.margined = 1;
 win.onClosing(function () {

--- a/examples/histogram.js
+++ b/examples/histogram.js
@@ -212,8 +212,6 @@ function redraw() {
 }
 
 function main() {
-	libui.Ui.init();
-
 	var hbox;
 	var vbox;
 	var i;

--- a/examples/text.js
+++ b/examples/text.js
@@ -61,8 +61,6 @@ function redraw() {
 }
 
 function main() {
-	libui.Ui.init();
-
 	var hbox;
 	var vbox;
 

--- a/examples/utils.js
+++ b/examples/utils.js
@@ -33,6 +33,9 @@ function menu(template) {
 						if (subMnu.click) {
 							subMnuObj.onClicked(subMnu.click);
 						}
+						if (subMnu.disabled) {
+							subMnuObj.disable();
+						}
 					}
 			}
 		}

--- a/examples/widgets/showUiButton.js
+++ b/examples/widgets/showUiButton.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiButton example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiCheckbox.js
+++ b/examples/widgets/showUiCheckbox.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiCheckbox example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiColorButton.js
+++ b/examples/widgets/showUiColorButton.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiColorButton example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiCombobox.js
+++ b/examples/widgets/showUiCombobox.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiCombobox example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiDatePicker.js
+++ b/examples/widgets/showUiDatePicker.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiDatePicker example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiDateTimePicker.js
+++ b/examples/widgets/showUiDateTimePicker.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiDateTimePicker example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiEditableCombobox.js
+++ b/examples/widgets/showUiEditableCombobox.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiEditableCombobox example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiEntry.js
+++ b/examples/widgets/showUiEntry.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiEntry example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiForm.js
+++ b/examples/widgets/showUiForm.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiForm example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiGrid.js
+++ b/examples/widgets/showUiGrid.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiGrid example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiGroup.js
+++ b/examples/widgets/showUiGroup.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiGroup example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiHorizontalBox.js
+++ b/examples/widgets/showUiHorizontalBox.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiHorizontalBox example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiHorizontalSeparator.js
+++ b/examples/widgets/showUiHorizontalSeparator.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiHorizontalSeparator example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiLabel.js
+++ b/examples/widgets/showUiLabel.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiLabel example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiMultilineEntry.js
+++ b/examples/widgets/showUiMultilineEntry.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiMultilineEntry example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiProgressBar.js
+++ b/examples/widgets/showUiProgressBar.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiProgressBar example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiRadioButtons.js
+++ b/examples/widgets/showUiRadioButtons.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiRadioButtons example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiSlider.js
+++ b/examples/widgets/showUiSlider.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiSlider example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiSpinbox.js
+++ b/examples/widgets/showUiSpinbox.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiSpinbox example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiTab.js
+++ b/examples/widgets/showUiTab.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiTab example', 320, 90, true);
 win.margined = true;
 

--- a/examples/widgets/showUiTimePicker.js
+++ b/examples/widgets/showUiTimePicker.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiTimePicker example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiVerticalBox.js
+++ b/examples/widgets/showUiVerticalBox.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiVerticalBox example', 320, 60, true);
 win.margined = true;
 

--- a/examples/widgets/showUiVerticalSeparator.js
+++ b/examples/widgets/showUiVerticalSeparator.js
@@ -1,7 +1,5 @@
-
 var libui = require('../../index');
 
-libui.Ui.init();
 var win = new libui.UiWindow('UiVerticalSeparator example', 320, 60, true);
 win.margined = true;
 


### PR DESCRIPTION
- `libui.Ui.init();` doesn't need to be called anymore
- Make the "Disabled Item" in control-gallery.js actually disabled.

Only tested on macOS. (First point caused crashes on Windows)

---

Was `examples/ControlGallery.app` commited on purpose?