### PR TITLE
Fix UiVerticalSeparator example

### DIFF
--- a/examples/widgets/showUiVerticalSeparator.js
+++ b/examples/widgets/showUiVerticalSeparator.js
@@ -5,9 +5,9 @@ win.margined = true;
 
 var widget = new libui.UiHorizontalBox();
 widget.padded = true;
-widget.append(new libui.UiMultilineEntry(), false);
+widget.append(new libui.UiMultilineEntry(), true);
 widget.append(new libui.UiVerticalSeparator(), false);
-widget.append(new libui.UiMultilineEntry(), false);
+widget.append(new libui.UiMultilineEntry(), true);
 win.setChild(widget);
 
 win.onClosing(function () {


### PR DESCRIPTION
Only tested on Mac

**Before:**
![bildschirmfoto 2018-03-21 um 19 58 41](https://user-images.githubusercontent.com/4586894/37731498-8c42d8d6-2d42-11e8-89f9-abdc4757c325.png)
or
![bildschirmfoto 2018-03-21 um 19 58 32](https://user-images.githubusercontent.com/4586894/37731502-8eb95086-2d42-11e8-9e2d-39649d901de9.png)
(jumped over after resizing)


**After:**
![bildschirmfoto 2018-03-21 um 19 58 57](https://user-images.githubusercontent.com/4586894/37731514-975a945c-2d42-11e8-8c72-c028f619332e.png)
