### PR TITLE
Some more improvements to UiArea

### DIFF
--- a/src/UiArea/UiArea.cc
+++ b/src/UiArea/UiArea.cc
@@ -2,8 +2,6 @@
 #include "control.h"
 #include "ui.h"
 
-std::map<uiArea *, UiArea *> areasMap;
-
 void UiArea::setSize(int width, int height) {
 	uiAreaSetSize((uiArea *)getHandle(), width, height);
 }
@@ -22,9 +20,7 @@ UiArea::UiArea(nbind::cbFunction &drawCb, nbind::cbFunction &mouseEventCb,
 	: UiControl(
 		  (uiControl *)uiNewArea((uiAreaHandler *)UiAreaHandlerFactory::build(
 			  drawCb, mouseEventCb, mouseCrossedCb, dragBrokenCb,
-			  keyEventCb))) {
-	areasMap[(uiArea *)getHandle()] = this;
-}
+			  keyEventCb))) {}
 
 UiArea::UiArea(nbind::cbFunction &drawCb, nbind::cbFunction &mouseEventCb,
 			   nbind::cbFunction &mouseCrossedCb,
@@ -33,18 +29,12 @@ UiArea::UiArea(nbind::cbFunction &drawCb, nbind::cbFunction &mouseEventCb,
 	: UiControl((uiControl *)uiNewScrollingArea(
 		  (uiAreaHandler *)UiAreaHandlerFactory::build(
 			  drawCb, mouseEventCb, mouseCrossedCb, dragBrokenCb, keyEventCb),
-		  width, height)) {
-	areasMap[(uiArea *)getHandle()] = this;
-}
-
-// Workaround for nbind bug solved in 0.3
-UiArea::UiArea(int dummy) : UiControl(NULL) {}
+		  width, height)) {}
 
 #include "nbind/api.h"
 
 NBIND_CLASS(UiArea) {
 	inherit(UiControl);
-	construct<int>();
 	construct<nbind::cbFunction &, nbind::cbFunction &, nbind::cbFunction &,
 			  nbind::cbFunction &, nbind::cbFunction &>();
 	construct<nbind::cbFunction &, nbind::cbFunction &, nbind::cbFunction &,

--- a/src/UiArea/UiAreaHandler.cc
+++ b/src/UiArea/UiAreaHandler.cc
@@ -3,25 +3,25 @@
 
 void Draw(UiAreaHandler *self, uiArea *area, uiAreaDrawParams *params) {
 	UiAreaDrawParams *pp = new UiAreaDrawParams(params);
-	(*self->draw)(areasMap[area], pp);
+	(*self->draw)(controlsMap[uiControl(area)], pp);
 }
 
 void MouseEvent(UiAreaHandler *self, uiArea *area, uiAreaMouseEvent *event) {
 	UiAreaMouseEvent *ev = new UiAreaMouseEvent(event);
-	(*(self->mouseEvent))(areasMap[area], ev);
+	(*(self->mouseEvent))(controlsMap[uiControl(area)], ev);
 }
 
 void MouseCrossed(UiAreaHandler *self, uiArea *area, int left) {
-	(*(self->mouseCrossed))(areasMap[area], left);
+	(*(self->mouseCrossed))(controlsMap[uiControl(area)], left);
 }
 
 void DragBroken(UiAreaHandler *self, uiArea *area) {
-	(*(self->dragBroken))(areasMap[area]);
+	(*(self->dragBroken))(controlsMap[uiControl(area)]);
 }
 
 int KeyEvent(UiAreaHandler *self, uiArea *area, uiAreaKeyEvent *event) {
 	UiAreaKeyEvent *ev = new UiAreaKeyEvent(event);
-	return (self->keyEvent)->call<int>(areasMap[area], ev);
+	return (self->keyEvent)->call<int>(controlsMap[uiControl(area)], ev);
 }
 
 UiAreaHandler *UiAreaHandlerFactory::build(nbind::cbFunction &drawCb,

--- a/src/includes/area.h
+++ b/src/includes/area.h
@@ -8,14 +8,9 @@
 #include "ui.h"
 #include "values.h"
 
-// UIArea
-
 // TODO - document
 class UiArea : public UiControl {
   public:
-	// Workaround for nbind bug solved in 0.3
-	UiArea(int dummy);
-
 	UiArea(nbind::cbFunction &drawCb, nbind::cbFunction &mouseEventCb,
 		   nbind::cbFunction &mouseCrossedCb, nbind::cbFunction &dragBrokenCb,
 		   nbind::cbFunction &keyEventCb);
@@ -26,8 +21,6 @@ class UiArea : public UiControl {
 	void queueRedrawAll();
 	void scrollTo(double x, double y, double width, double height);
 };
-
-extern std::map<uiArea *, UiArea *> areasMap;
 
 class DrawStrokeParams {
   private:

--- a/src/includes/control.h
+++ b/src/includes/control.h
@@ -1,6 +1,7 @@
 #ifndef UI_NODE_CONTROL
 #define UI_NODE_CONTROL 1
 
+#include <map>
 #include "ui.h"
 
 #define DEFINE_EVENT(NAME)                                                     \
@@ -48,6 +49,8 @@ class UiControl {
 	bool getEnabled();
 	void setEnabled(bool enabled);
 };
+
+extern std::map<uiControl *, UiControl *> controlsMap;
 
 // This is included at end of file
 // to minimize conflicts with existing


### PR DESCRIPTION
* Replaces areasMap with controlsMap that now serve the same purpose for all controls.
* Removed the now unneeded <int> constructor from UiArea. It was a workaround for an nbind bug now solved.