### PR TITLE
update dependencies to streamline compile and reduce audit warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ node_js:
   - '10'
   - '9'
   - '8'
-  - '6'
-  - '4'
 
 sudo: required
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,8 +7,6 @@ environment:
     - nodejs_version: "10"
     - nodejs_version: "9"
     - nodejs_version: "8"
-    - nodejs_version: "6"
-    - nodejs_version: "4"
 
 install:
   - ps: Install-Product node $env:nodejs_version x64

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
 		"GUI"
 	],
 	"engines": {
-		"node": ">=4"
+		"node": ">=8.9.4 <9 || >=10.0.0 <11"
 	},
 	"files": [
 		"list-sources.js",
@@ -55,7 +55,7 @@
 		"autogypi.json"
 	],
 	"devDependencies": {
-		"ava": "^0.25.0",
+		"ava": "^2.4.0",
 		"clang-format": "^1.2.2",
 		"humanize": "0.0.9",
 		"husky": "^0.14.3",
@@ -65,7 +65,7 @@
 		"@mischnic/async-hooks": "^0.0.4",
 		"autogypi": "^0.2.2",
 		"libui-download": "^1.1.0",
-		"nbind": "^0.3.14",
-		"node-gyp": "^3.3.1"
+		"nbind": "^0.3.15",
+		"node-gyp": "^6.0.1"
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ Windows
 * Windows: Windows Vista SP2 with Platform Update or newer
 * Unix: GTK+ 3.10 or newer
 * Mac OS X: OS X 10.8 or newer
-* Node.js version 4 or greater.
+* Node.js: v8 and v10 (but not v12 due to charto/nbind#133)
 
 # Prerequisites
 


### PR DESCRIPTION
Dependency version changes:
* Update avajs/ava, to use version of fsevents that compiles on node v10 and reduces number of audit warnings.
* Update nodejs/node-gyp, to reduce number of audit warnings.
* Update charto/nbind, to avoid typescript build error.
* Update supported engine versions, due to avajs/ava only supporting node > v8.  Also node < v8 are out of maintenance.  https://nodejs.org/en/about/releases/